### PR TITLE
API: Return the modification history of a property of an item uncompr…

### DIFF
--- a/Server/htdocs/AppController/commands_RSM/api/api_getAuditTrail.php
+++ b/Server/htdocs/AppController/commands_RSM/api/api_getAuditTrail.php
@@ -5,6 +5,8 @@ require_once "../utilities/RSMitemsManagement.php";
 require_once "../utilities/RStools.php";
 require_once "./api_headers.php";
 
+$RSallowUncompressed = true;
+
 // Check the variables
 isset($GLOBALS['RS_POST']['clientID'  ]) ? $clientID   = $GLOBALS['RS_POST']['clientID'  ] : dieWithError(400);
 isset($GLOBALS['RS_POST']['itemID'    ]) ? $itemID     = $GLOBALS['RS_POST']['itemID'    ] : dieWithError(400);
@@ -23,6 +25,6 @@ if ((!RShasREADTokenPermission($RStoken, $propertyID)) && (!isPropertyVisible($R
 // Process response
 $results = getAuditTrail($clientID, $propertyID, $itemID);
 
-// And return XML response back to application
-RSReturnArrayQueryResults($results);
+// And return XML response back to application without compression
+RSReturnArrayQueryResults($results, false);
 ?>


### PR DESCRIPTION
It only makes sense to return the response compressed if the number of expected modifications and the size of each one is very large, but in general it will be comparable to the return of the item itself. For this reason, and to make it the same as getItem, getItems, etc., we enable the uncompressed response.